### PR TITLE
README typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is the repository for [pitest.org](pitest.org)
+This is the repository for [pitest.org](https://pitest.org)
 
 # Run locally
 
@@ -7,6 +7,6 @@ The site in hosted by [GitHub Pages](https://pages.github.com/) and uses
 
 To run the site locally you first need to install a [ruby development environment](https://jekyllrb.com/docs/installation/).
 
-Then run `bundle installl`.
+Then run `bundle install`.
 
 Finally run `bundle exec jekyll serve` to get a local site running at [http://localhost:4000](http://localhost:4000).


### PR DESCRIPTION
- the `bundle installl` command with its 3 'l's has one too many
- the link to the website doesn't work (anymore ?) whithout prefixing it with the protocol